### PR TITLE
Backend domain is dynamic and not hardcoded anymore

### DIFF
--- a/src/Config/api.js
+++ b/src/Config/api.js
@@ -2,5 +2,5 @@
 export let basePath;
 export let cloudDomain;
 cloudDomain = "blackbird-osint.herokuapp.com";
-basePath = window.location.protocol + "://" +
+basePath = window.location.protocol + "//" +
            window.location.host + "/";

--- a/src/Config/api.js
+++ b/src/Config/api.js
@@ -2,5 +2,8 @@
 export let basePath;
 export let cloudDomain;
 cloudDomain = "blackbird-osint.herokuapp.com";
-basePath = window.location.protocol + "//" +
-           window.location.host + "/";
+if (window.location.hostname == cloudDomain) {
+    basePath = "https://" + cloudDomain + "/";
+} else {
+    basePath = window.location.protocol + "//" + window.location.host + "/";
+}

--- a/src/Config/api.js
+++ b/src/Config/api.js
@@ -2,9 +2,5 @@
 export let basePath;
 export let cloudDomain;
 cloudDomain = "blackbird-osint.herokuapp.com";
-if (window.location.hostname == cloudDomain) {
-  basePath = "https://" + cloudDomain + "/";
-}else{
-  basePath = window.location.protocol + "://" +
-             window.location.host + ":" + "/";
-}
+basePath = window.location.protocol + "://" +
+           window.location.host + "/";

--- a/src/Config/api.js
+++ b/src/Config/api.js
@@ -4,6 +4,7 @@ export let cloudDomain;
 cloudDomain = "blackbird-osint.herokuapp.com";
 if (window.location.hostname == cloudDomain) {
   basePath = "https://" + cloudDomain + "/";
-} else {
-  basePath = "http://127.0.0.1:9797/";
+}else{
+  basePath = window.location.protocol + "://" +
+             window.location.host + ":" + "/";
 }


### PR DESCRIPTION
This is a fix for [issue 19](https://github.com/p1ngul1n0/blackbird/issues/19) from the backend Repo of blackbird.

Instead of checking against a given domain and set a variable to localhost if `false` the code now retrieves the url from the browser (`window.location.*`) and concats it to the `basePath`.

A check against the `cloudDomain` is not necessary anymore as thi leads to the very same result in `basePath`.

However, I was not able to test this code with a connected backend as I don't know how to connect backend and frontend.

The code builds fine in a node.js Docker.